### PR TITLE
Test provider and repository

### DIFF
--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_shuttletracker/data/models/shuttle_route.dart';
+import 'package:flutter_shuttletracker/data/models/shuttle_stop.dart';
+import 'package:flutter_shuttletracker/data/models/shuttle_update.dart';
+import 'package:flutter_shuttletracker/data/provider/shuttle_api_provider.dart';
+
+void main() {
+  final provider = ShuttleApiProvider();
+  group(
+    'Provider tests',
+    () {
+      test('Routes test', () async {
+        final routes = await provider.getRoutes();
+        expect(routes, isNotNull);
+        expect(routes, isA<List>());
+        routes.forEach((route) {
+          expect(route, isNotNull);
+          expect(route, isA<ShuttleRoute>());
+        });
+      });
+
+      test('Stops test', () async {
+        final stops = await provider.getStops();
+        expect(stops, isNotNull);
+        expect(stops, isA<List>());
+        stops.forEach((stop) {
+          expect(stop, isNotNull);
+          expect(stop, isA<ShuttleStop>());
+        });
+      });
+
+      test('Updates test', () async {
+        final updates = await provider.getUpdates();
+        expect(updates, isNotNull);
+        expect(updates, isA<List>());
+        updates.forEach((update) {
+          expect(update, isNotNull);
+          expect(update, isA<ShuttleUpdate>());
+        });
+      });
+
+      test('Connection test', () async {
+        // Dummy call to check the connection
+        provider.getRoutes();
+        final connected = provider.getIsConnected;
+        expect(connected, true);
+      });
+    },
+  );
+}

--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -10,6 +10,11 @@ void main() {
   group(
     'Provider tests',
     () {
+      // Can't test much here except that nothing is null and the types are
+      // what they should be, as we don't know how many routes, stops, or
+      // updates we'll be receiving from the datafeed, if any, or anything
+      // about them
+
       test('Routes test', () async {
         final routes = await provider.getRoutes();
         expect(routes, isNotNull);

--- a/test/repository_test.dart
+++ b/test/repository_test.dart
@@ -3,10 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter_shuttletracker/data/models/shuttle_route.dart';
-import 'package:flutter_shuttletracker/data/models/shuttle_stop.dart';
-import 'package:flutter_shuttletracker/data/models/shuttle_update.dart';
 import 'package:flutter_shuttletracker/data/repository/shuttle_repository.dart';
 import 'package:flutter_shuttletracker/global_widgets/shuttle_svg.dart';
+import 'package:flutter_shuttletracker/theme/helpers.dart';
 
 void main() {
   final repository = ShuttleRepository();
@@ -36,12 +35,20 @@ void main() {
 
       test('Dark routes test', () async {
         final darkRoutes = await repository.getDarkRoutes();
+        final lightRoutes = await repository.getRoutes;
         expect(darkRoutes, isNotNull);
         expect(darkRoutes, isA<List>());
         darkRoutes.forEach((darkRoute) {
           expect(darkRoute, isNotNull);
           expect(darkRoute, isA<ShuttleRoute>());
-          // TODO: ensure color is correct for dark route
+          // Find corresponding light route for color comparison
+          var lightRouteColor;
+          for (final lightRoute in lightRoutes) {
+            if (lightRoute.name == darkRoute.name) {
+              lightRouteColor = lightRoute.color;
+            }
+          }
+          expect(darkRoute.color, shadeColor(lightRouteColor, 0.35));
         });
       });
 
@@ -60,9 +67,9 @@ void main() {
         });
 
         expect(data.legend, isNotNull);
-        data.legend.forEach((id, svg) {
-          expect(id, isNotNull);
-          expect(id, isA<int>());
+        data.legend.forEach((routeName, svg) {
+          expect(routeName, isNotNull);
+          expect(routeName, isA<String>());
           expect(svg, isNotNull);
           expect(svg, isA<ShuttleSVG>());
         });
@@ -81,7 +88,8 @@ void main() {
           expect(routeName, isA<String>());
           expect(svg, isNotNull);
           expect(svg, isA<ShuttleSVG>());
-          // TODO: ensure SVG color is correct for dark mode
+          expect(
+              svg.svgColor, shadeColor(data.legend[routeName].svgColor, 0.35));
         });
       });
     },

--- a/test/repository_test.dart
+++ b/test/repository_test.dart
@@ -33,7 +33,22 @@ void main() {
         expect(updates, isA<List>());
       });
 
-      test('Dark routes test', () async {
+      test('Dark routes match test', () async {
+        final darkRoutes = await repository.getDarkRoutes();
+        final lightRoutes = await repository.getRoutes;
+        darkRoutes.forEach((darkRoute) {
+          var foundMatch = false;
+          for (final lightRoute in lightRoutes) {
+            if (lightRoute.name == darkRoute.name) {
+              foundMatch = true;
+              break;
+            }
+          }
+          expect(foundMatch, true);
+        });
+      });
+
+      test('Dark routes color test', () async {
         final darkRoutes = await repository.getDarkRoutes();
         final lightRoutes = await repository.getRoutes;
         expect(darkRoutes, isNotNull);
@@ -46,6 +61,7 @@ void main() {
           for (final lightRoute in lightRoutes) {
             if (lightRoute.name == darkRoute.name) {
               lightRouteColor = lightRoute.color;
+              break;
             }
           }
           expect(darkRoute.color, shadeColor(lightRouteColor, 0.35));
@@ -90,6 +106,7 @@ void main() {
           expect(svg, isA<ShuttleSVG>());
           expect(
               svg.svgColor, shadeColor(data.legend[routeName].svgColor, 0.35));
+          expect(data.legend.containsKey(routeName), true);
         });
       });
     },

--- a/test/repository_test.dart
+++ b/test/repository_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter_shuttletracker/data/models/shuttle_route.dart';
+import 'package:flutter_shuttletracker/data/models/shuttle_stop.dart';
+import 'package:flutter_shuttletracker/data/models/shuttle_update.dart';
+import 'package:flutter_shuttletracker/data/repository/shuttle_repository.dart';
+import 'package:flutter_shuttletracker/global_widgets/shuttle_svg.dart';
+
+void main() {
+  final repository = ShuttleRepository();
+  group(
+    'Repository tests',
+    () {
+      test('Routes test', () async {
+        // More rigorous testing occurs in the provider tests
+        final routes = repository.getRoutes;
+        expect(routes, isNotNull);
+        expect(routes, isA<List>());
+      });
+
+      test('Stops test', () async {
+        // More rigorous testing occurs in the provider tests
+        final stops = repository.getStops;
+        expect(stops, isNotNull);
+        expect(stops, isA<List>());
+      });
+
+      test('Updates test', () async {
+        // More rigorous testing occurs in the provider tests
+        final updates = repository.getRoutes;
+        expect(updates, isNotNull);
+        expect(updates, isA<List>());
+      });
+
+      test('Dark routes test', () async {
+        final darkRoutes = await repository.getDarkRoutes();
+        expect(darkRoutes, isNotNull);
+        expect(darkRoutes, isA<List>());
+        darkRoutes.forEach((darkRoute) {
+          expect(darkRoute, isNotNull);
+          expect(darkRoute, isA<ShuttleRoute>());
+          // TODO: ensure color is correct for dark route
+        });
+      });
+
+      test('Auxiliary data test', () async {
+        final data = await repository.getAuxiliaryRouteData();
+
+        // Can't test much here except that nothing is null and all types are
+        // what they should be, as we don't know how much route data we will
+        // receive, if any
+
+        expect(data.ids, isNotNull);
+        expect(data.ids, isA<List>());
+        data.ids.forEach((id) {
+          expect(id, isNotNull);
+          expect(id, isA<int>());
+        });
+
+        expect(data.legend, isNotNull);
+        data.legend.forEach((id, svg) {
+          expect(id, isNotNull);
+          expect(id, isA<int>());
+          expect(svg, isNotNull);
+          expect(svg, isA<ShuttleSVG>());
+        });
+
+        expect(data.colors, isNotNull);
+        data.colors.forEach((id, color) {
+          expect(id, isNotNull);
+          expect(id, isA<int>());
+          expect(color, isNotNull);
+          expect(color, isA<Color>());
+        });
+
+        expect(data.darkLegend, isNotNull);
+        data.darkLegend.forEach((routeName, svg) {
+          expect(routeName, isNotNull);
+          expect(routeName, isA<String>());
+          expect(svg, isNotNull);
+          expect(svg, isA<ShuttleSVG>());
+          // TODO: ensure SVG color is correct for dark mode
+        });
+      });
+    },
+  );
+}

--- a/test/repository_test.dart
+++ b/test/repository_test.dart
@@ -14,21 +14,21 @@ void main() {
     () {
       test('Routes test', () async {
         // More rigorous testing occurs in the provider tests
-        final routes = repository.getRoutes;
+        final routes = await repository.getRoutes;
         expect(routes, isNotNull);
         expect(routes, isA<List>());
       });
 
       test('Stops test', () async {
         // More rigorous testing occurs in the provider tests
-        final stops = repository.getStops;
+        final stops = await repository.getStops;
         expect(stops, isNotNull);
         expect(stops, isA<List>());
       });
 
       test('Updates test', () async {
         // More rigorous testing occurs in the provider tests
-        final updates = repository.getRoutes;
+        final updates = await repository.getRoutes;
         expect(updates, isNotNull);
         expect(updates, isA<List>());
       });


### PR DESCRIPTION
Created tests to ensure the data received from the provider and repository is valid. Since no assumptions can be made about the data that will be received at any given time, these tests primarily ensure that nothing received from the datafeed is null, everything is the proper type, and dark routes have the proper color and have a corresponding light route.