### PR TITLE
Test color helper functions

### DIFF
--- a/test/helper_test.dart
+++ b/test/helper_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:flutter/material.dart';
+
+import 'package:flutter_shuttletracker/theme/helpers.dart';
+
+void main() {
+  group(
+    'Helper tests',
+    () {
+      test('Luma test', () {
+        final lightColor = shadeColor(Color(int.parse('0xff0000ff')), 0.35);
+        final darkColor = shadeColor(Color(int.parse('0xff0000ff')), 0.70);
+        // Coefficients from Rec. 709
+        final lightLuma = 0.2126 * lightColor.red +
+            0.7152 * lightColor.green +
+            0.0722 * lightColor.blue;
+        final darkLuma = 0.2126 * darkColor.red +
+            0.7152 * darkColor.green +
+            0.0722 * darkColor.blue;
+        expect(darkLuma, lessThan(lightLuma));
+      });
+    },
+  );
+}

--- a/test/helper_test.dart
+++ b/test/helper_test.dart
@@ -8,7 +8,7 @@ void main() {
   group(
     'Helper tests',
     () {
-      test('Luma test', () {
+      test('Shade color test', () {
         final lightColor = shadeColor(Color(int.parse('0xff0000ff')), 0.35);
         final darkColor = shadeColor(Color(int.parse('0xff0000ff')), 0.70);
         // Coefficients from Rec. 709
@@ -19,6 +19,13 @@ void main() {
             0.7152 * darkColor.green +
             0.0722 * darkColor.blue;
         expect(darkLuma, lessThan(lightLuma));
+      });
+
+      test('Shade value test', () {
+        final color = Color(int.parse('0xff0000ff'));
+        final lightValue = shadeValue(color.blue, 0.70);
+        final darkValue = shadeValue(color.blue, 0.35);
+        expect(lightValue, lessThan(darkValue));
       });
     },
   );


### PR DESCRIPTION
Added a new test group for the helper functions `shadeColor` and `shadeValue`. One of these tests uses the luma coefficients from the [Recommendation 709](https://en.wikipedia.org/wiki/Rec._709) standard to determine and compare the darkness of a color after altering the shade by different amounts, and the other simply compares the blue channel of a color after its shade has been altered by different amounts.